### PR TITLE
Driver module

### DIFF
--- a/Core/Inc/ecu/driver/driver-api.h
+++ b/Core/Inc/ecu/driver/driver-api.h
@@ -1,0 +1,52 @@
+/*!
+ * \file driver-api.h
+ * \author Dorijan Di Zepp
+ * \date 2026-05-13
+ * \brief API for driver selection, readiness verification before R2D transition
+ * and continuous safety monitoring during operation.
+ */
+
+#ifndef DRIVER_API_H
+#define DRIVER_API_H
+
+#include "driver.h"
+
+/*!
+ * \brief Initializes the driver handler by storing the driver type and necessary callbacks.
+ * \note It is recommended to initialize the module with \ref DRIVER_TYPE_MANUAL by default. 
+ * This establishes a **fail-safe default configuration**, ensuring that human control 
+ * is the baseline state upon system boot or reset. This prevents the vehicle from 
+ * defaulting to autonomous control (AS) without explicit, intentional selection.
+ * \warning Initialization and driver switching are only permitted in the "Init" or "Idle" states. 
+ * This ensures that the vehicle operates under a deterministic driver assignment in all 
+ * subsequent operational states.
+ * \param[in] driver_type The driver selected to operate the vehicle.
+ * \param[in] wait_for_driver Callback to determine if the driver is ready to drive.
+ * \param[in] continuous_check Callback to verify basic safety conditions during driving.
+ * \retval DRIVER_RC_OK If the initialization was successful.
+ * \retval DRIVER_RC_ERROR If a callback is \c NULL, the state is invalid or the driver type is not valid.
+ */
+enum DriverReturnCode driver_api_init(enum DriverType driver_type, driver_wait_for_driver_callback wait_for_driver, driver_continuous_check_callback continuous_check);
+
+/*!
+ * \brief Verifies if the driver is ready to drive.
+ * \note The outcome is determined solely by the logic defined within the 
+ * \ref driver_wait_for_driver_callback.
+ * \note The result is typically used by the FSM to trigger a transition to the R2D state.
+ * \retval DRIVER_RC_OK Driver meets all readiness conditions.
+ * \retval DRIVER_RC_ERROR Driver is NOT ready or the internal callback is \c NULL.
+ */
+enum DriverReturnCode driver_api_is_driver_ready(void);
+
+/*!
+ * \brief Performs continuous safety monitoring during the driving phase.
+ * \details This function verifies that critical operating conditions are met. 
+ * Failure of these checks usually mandates immediate inverter deactivation for safety.
+ * \note The result is intended for use by the FSM (specifically in the R2D state) 
+ * to decide if the inverters or Autonomous System must be disabled.
+ * \retval DRIVER_RC_OK All safety conditions are met; car is safe to drive.
+ * \retval DRIVER_RC_ERROR A safety check failed or the callback is \c NULL; stop the vehicle.
+ */
+enum DriverReturnCode driver_api_continuous_check(void);
+
+#endif

--- a/Core/Inc/ecu/driver/driver-api.h
+++ b/Core/Inc/ecu/driver/driver-api.h
@@ -13,6 +13,7 @@
 
 /*!
  * \brief Initializes the driver handler by storing the driver type and necessary callbacks.
+ * \note If the initialization is not successful, the previous configuration is left unchanged.
  * \note It is recommended to initialize the module with \ref DRIVER_TYPE_MANUAL by default. 
  * This establishes a **fail-safe default configuration**, ensuring that human control 
  * is the baseline state upon system boot or reset. This prevents the vehicle from 

--- a/Core/Inc/ecu/driver/driver-api.h
+++ b/Core/Inc/ecu/driver/driver-api.h
@@ -1,7 +1,7 @@
 /*!
  * \file driver-api.h
  * \author Dorijan Di Zepp
- * \date 2026-05-13
+ * \date 2026-05-14
  * \brief API for driver selection, readiness verification before R2D transition
  * and continuous safety monitoring during operation.
  */
@@ -43,10 +43,16 @@ enum DriverReturnCode driver_api_is_driver_ready(void);
  * \details This function verifies that critical operating conditions are met. 
  * Failure of these checks usually mandates immediate inverter deactivation for safety.
  * \note The result is intended for use by the FSM (specifically in the R2D state) 
- * to decide if the inverters or Autonomous System must be disabled.
+ * to decide if the inverters or Autonomous System must be disabled without explicit user request.
  * \retval DRIVER_RC_OK All safety conditions are met; car is safe to drive.
  * \retval DRIVER_RC_ERROR A safety check failed or the callback is \c NULL; stop the vehicle.
  */
 enum DriverReturnCode driver_api_continuous_check(void);
+
+/*!
+ * \brief Returns the currently selected driver type.
+ * \return The active \ref DriverType (e.g. MANUAL or AS).
+ */
+enum DriverType driver_api_get_driver_type(void);
 
 #endif

--- a/Core/Inc/ecu/driver/driver.h
+++ b/Core/Inc/ecu/driver/driver.h
@@ -1,7 +1,7 @@
 /*!
  * \file driver.h
  * \author Dorijan Di Zepp
- * \date 2026-05-13
+ * \date 2026-05-14
  * \brief Management of driver selection, readiness checks and 
  * continuous safety monitoring.
  */
@@ -10,7 +10,7 @@
 #define DRIVER_H
 
 /*!
- * \brief Return codes for the driver module APIs
+ * \brief Return codes for the driver module APIs.
  */
 enum DriverReturnCode {
     DRIVER_RC_OK,    /*!< Operation completed successfully */
@@ -29,7 +29,7 @@ enum DriverType {
 /*!
  * \brief Callback signature to determine if the driver is ready.
  * This function is typically polled while the car is in a pre-drive state 
- * (e.g., IDLE) to determine if transition to R2D is permitted.
+ * (e.g. IDLE) to determine if transition to R2D is permitted.
  * \retval DRIVER_RC_OK    Driver is ready; all checks passed.
  * \retval DRIVER_RC_ERROR Driver is not ready; checks failed.
  */

--- a/Core/Inc/ecu/driver/driver.h
+++ b/Core/Inc/ecu/driver/driver.h
@@ -1,0 +1,58 @@
+/*!
+ * \file driver.h
+ * \author Dorijan Di Zepp
+ * \date 2026-05-13
+ * \brief Management of driver selection, readiness checks and 
+ * continuous safety monitoring.
+ */
+
+#ifndef DRIVER_H
+#define DRIVER_H
+
+/*!
+ * \brief Return codes for the driver module APIs
+ */
+enum DriverReturnCode {
+    DRIVER_RC_OK,    /*!< Operation completed successfully */
+    DRIVER_RC_ERROR, /*!< The requested operation failed or returned a negative outcome */
+};
+
+/*!
+ * \brief Supported driver types for vehicle control.
+ */
+enum DriverType {
+    DRIVER_TYPE_MANUAL, /*!< Human driver is selected. */
+    DRIVER_TYPE_AS,     /*!< Autonomous System (AS) is selected. */
+    DRIVER_TYPE_COUNT,  /*!< Sentinel for range validation. */
+};
+
+/*!
+ * \brief Callback signature to determine if the driver is ready.
+ * This function is typically polled while the car is in a pre-drive state 
+ * (e.g., IDLE) to determine if transition to R2D is permitted.
+ * \retval DRIVER_RC_OK    Driver is ready; all checks passed.
+ * \retval DRIVER_RC_ERROR Driver is not ready; checks failed.
+ */
+typedef enum DriverReturnCode (*driver_wait_for_driver_callback)(void);
+
+/*!
+ * \brief Callback signature for continuous safety monitoring.
+ * This function is invoked repeatedly during driving states to ensure 
+ * operational conditions remain within safety limits.
+ * \retval DRIVER_RC_OK    Conditions are safe; continue operation.
+ * \retval DRIVER_RC_ERROR Safety violation detected; vehicle should be stopped.
+ */
+typedef enum DriverReturnCode (*driver_continuous_check_callback)(void);
+
+/*!
+ * \brief Handler for the driver control module.
+ */
+struct DriverHandler {
+    enum DriverType driver_type; /*!< Selected driver type. */
+
+    driver_wait_for_driver_callback wait_for_driver; /*!< Readiness check callback. */
+
+    driver_continuous_check_callback continuous_check; /*!< Safety monitoring callback. */
+};
+
+#endif

--- a/Core/Src/ecu/driver/driver-api.c
+++ b/Core/Src/ecu/driver/driver-api.c
@@ -1,0 +1,69 @@
+/*!
+ * \file driver-api.c
+ * \author Dorijan Di Zepp
+ * \date 2026-05-13
+ * \brief Implementation of the driver control and monitoring API.
+ */
+
+#include <string.h>
+#include "driver-api.h"
+#include "ecu_fsm.h"
+#include "eagletrt-api.h"
+
+/*!
+ * \brief Static driver handler
+ */
+EAGLETRT_STATIC struct DriverHandler driver_handler;
+
+/*!
+ * \brief Reference to the vehicle's global Finite State Machine state.
+ * \note Defined in \ref main.c (production) or \ref support_external.c (unit tests).
+ */
+extern state_t current_state;
+
+enum DriverReturnCode driver_api_init(enum DriverType driver_type, driver_wait_for_driver_callback wait_for_driver, driver_continuous_check_callback continuous_check) {
+    // verify if the function is called only if in Init or Idle state
+    if (current_state != STATE_INIT && current_state != STATE_IDLE) {
+        return DRIVER_RC_ERROR;
+    }
+
+    // as the init function can be called many times in init or idle
+    // it is required to first validate the parameters and
+    // then reset the values to avoid loosing the past valid configuration
+    if (driver_type >= DRIVER_TYPE_COUNT || (wait_for_driver == NULL) || (continuous_check == NULL)) {
+        return DRIVER_RC_ERROR;
+    }
+
+    // all parameters are valid
+    // memset to zero to avoid unexpected values
+    memset(&driver_handler, 0U, sizeof(struct DriverHandler));
+
+    driver_handler.driver_type = driver_type;
+
+    driver_handler.wait_for_driver = wait_for_driver;
+    driver_handler.continuous_check = continuous_check;
+
+    return DRIVER_RC_OK;
+}
+
+enum DriverReturnCode driver_api_is_driver_ready(void) {
+    // all the logic is defined inside the callback meaning that
+    // the function return code is based entirely on the return code
+    // of the callback
+    if (driver_handler.wait_for_driver == NULL) {
+        return DRIVER_RC_ERROR;
+    }
+
+    return driver_handler.wait_for_driver();
+}
+
+enum DriverReturnCode driver_api_continuous_check(void) {
+    // all the logic is defined inside the callback meaning that
+    // the function return code is based entirely on the return code
+    // of the callback
+    if (driver_handler.continuous_check == NULL) {
+        return DRIVER_RC_ERROR;
+    }
+
+    return driver_handler.continuous_check();
+}

--- a/Core/Src/ecu/driver/driver-api.c
+++ b/Core/Src/ecu/driver/driver-api.c
@@ -27,7 +27,7 @@ enum DriverReturnCode driver_api_init(enum DriverType driver_type, driver_wait_f
         return DRIVER_RC_ERROR;
     }
 
-    // Ss the init function can be called many times in init or idle
+    // Since the init function can be called many times in init or idle
     // it is required to first validate the parameters and
     // then reset the values to avoid loosing the past valid configuration
     if (driver_type >= DRIVER_TYPE_COUNT || (wait_for_driver == NULL) || (continuous_check == NULL)) {

--- a/Core/Src/ecu/driver/driver-api.c
+++ b/Core/Src/ecu/driver/driver-api.c
@@ -1,7 +1,7 @@
 /*!
  * \file driver-api.c
  * \author Dorijan Di Zepp
- * \date 2026-05-13
+ * \date 2026-05-14
  * \brief Implementation of the driver control and monitoring API.
  */
 
@@ -11,30 +11,30 @@
 #include "eagletrt-api.h"
 
 /*!
- * \brief Static driver handler
+ * \brief Static driver handler.
  */
 EAGLETRT_STATIC struct DriverHandler driver_handler;
 
 /*!
  * \brief Reference to the vehicle's global Finite State Machine state.
- * \note Defined in \ref main.c (production) or \ref support_external.c (unit tests).
+ * \note Defined in \ref main.c .
  */
 extern state_t current_state;
 
 enum DriverReturnCode driver_api_init(enum DriverType driver_type, driver_wait_for_driver_callback wait_for_driver, driver_continuous_check_callback continuous_check) {
-    // verify if the function is called only if in Init or Idle state
+    // Verify if the function is called only if in Init or Idle state
     if (current_state != STATE_INIT && current_state != STATE_IDLE) {
         return DRIVER_RC_ERROR;
     }
 
-    // as the init function can be called many times in init or idle
+    // Ss the init function can be called many times in init or idle
     // it is required to first validate the parameters and
     // then reset the values to avoid loosing the past valid configuration
     if (driver_type >= DRIVER_TYPE_COUNT || (wait_for_driver == NULL) || (continuous_check == NULL)) {
         return DRIVER_RC_ERROR;
     }
 
-    // all parameters are valid
+    // All parameters are valid
     // memset to zero to avoid unexpected values
     memset(&driver_handler, 0U, sizeof(struct DriverHandler));
 
@@ -47,7 +47,7 @@ enum DriverReturnCode driver_api_init(enum DriverType driver_type, driver_wait_f
 }
 
 enum DriverReturnCode driver_api_is_driver_ready(void) {
-    // all the logic is defined inside the callback meaning that
+    // All the logic is defined within the callback meaning that
     // the function return code is based entirely on the return code
     // of the callback
     if (driver_handler.wait_for_driver == NULL) {
@@ -58,7 +58,7 @@ enum DriverReturnCode driver_api_is_driver_ready(void) {
 }
 
 enum DriverReturnCode driver_api_continuous_check(void) {
-    // all the logic is defined inside the callback meaning that
+    // All the logic is defined within the callback meaning that
     // the function return code is based entirely on the return code
     // of the callback
     if (driver_handler.continuous_check == NULL) {
@@ -66,4 +66,8 @@ enum DriverReturnCode driver_api_continuous_check(void) {
     }
 
     return driver_handler.continuous_check();
+}
+
+enum DriverType driver_api_get_driver_type(void) {
+    return driver_handler.driver_type;
 }

--- a/Core/Test/support/support_external.c
+++ b/Core/Test/support/support_external.c
@@ -15,7 +15,7 @@
 /*!
  * \brief The global state of the Finite State Machine (FSM).
  * \details This variable represents the current operational state 
- * of the vehicle (e.g., INIT, IDLE, R2D). Modules like driver-api.c use 
+ * of the vehicle (e.g. INIT, IDLE, R2D). Modules like \ref driver-api.c use 
  * this variable to verify if certain actions (like re-initialization) 
  * are permitted in the current context.
  * In tests, this can be manually manipulated to simulate different car conditions.

--- a/Core/Test/support/support_external.c
+++ b/Core/Test/support/support_external.c
@@ -1,0 +1,23 @@
+/*!
+ * \file support_external.c
+ * \author Dorijan Di Zepp
+ * \date 2026-05-13
+ * \brief Global variable stubs for unit testing.
+ *
+ * \details In the production environment, certain global variables are defined in main.c.
+ * Since main.c is excluded from unit tests to avoid hardware dependencies,
+ * this file provides the necessary memory definitions for the 
+ * linker to resolve 'extern' references used by the modules under test.
+ */
+
+#include "ecu_fsm.h"
+
+/*!
+ * \brief The global state of the Finite State Machine (FSM).
+ * \details This variable represents the current operational state 
+ * of the vehicle (e.g., INIT, IDLE, R2D). Modules like driver-api.c use 
+ * this variable to verify if certain actions (like re-initialization) 
+ * are permitted in the current context.
+ * In tests, this can be manually manipulated to simulate different car conditions.
+ */
+state_t current_state = STATE_INIT;

--- a/Core/Test/test_driver/test_driver.c
+++ b/Core/Test/test_driver/test_driver.c
@@ -1,7 +1,7 @@
 /*!
  * \file test_driver.c
  * \author Dorijan Di Zepp
- * \date 2026-05-13
+ * \date 2026-05-14
  * \brief Unit tests using FFF for testing the driver module.
  */
 
@@ -21,7 +21,7 @@ extern state_t current_state;
 
 DEFINE_FFF_GLOBALS;
 
-// mock for driver module
+// Mocks for driver module
 FAKE_VALUE_FUNC(enum DriverReturnCode, wait_for_driver);
 FAKE_VALUE_FUNC(enum DriverReturnCode, continuous_check);
 
@@ -41,8 +41,144 @@ void setUp(void) {
 
 /* --- Test Cases --- */
 
+/*!
+ * \defgroup driver_api_init Tests for driver_api_init function
+ * \{
+ */
+
+void test_driver_api_init_invalid_driver_type(void) {
+    enum DriverReturnCode rc = driver_api_init(99U, wait_for_driver, continuous_check);
+
+    TEST_ASSERT_EQUAL_MESSAGE(DRIVER_RC_ERROR, rc, "Init should fail if the driver type passed is not valid");
+}
+
+void test_driver_api_init_null_wait_for_driver_callback(void) {
+    enum DriverReturnCode rc = driver_api_init(DRIVER_TYPE_MANUAL, NULL, continuous_check);
+
+    TEST_ASSERT_EQUAL_MESSAGE(DRIVER_RC_ERROR, rc, "Init should fail if wait for driver callback is NULL");
+}
+
+void test_driver_api_init_null_continuous_check_callback(void) {
+    enum DriverReturnCode rc = driver_api_init(DRIVER_TYPE_MANUAL, wait_for_driver, NULL);
+
+    TEST_ASSERT_EQUAL_MESSAGE(DRIVER_RC_ERROR, rc, "Init should fail if the continuous check callback is NULL");
+}
+
+void test_driver_api_init_not_in_init_and_idle(void) {
+    // set the current FSM state to any state different from
+    // both init and idle
+    current_state = STATE_R2D;
+
+    enum DriverReturnCode rc = driver_api_init(DRIVER_TYPE_MANUAL, wait_for_driver, continuous_check);
+
+    TEST_ASSERT_EQUAL_MESSAGE(DRIVER_RC_ERROR, rc, "Init should fail current FSM state is neither Init and Idle");
+}
+
+void test_driver_api_init_on_init_state(void) {
+    // a valid state is init to allow module initialization
+    current_state = STATE_INIT;
+
+    enum DriverReturnCode rc = driver_api_init(DRIVER_TYPE_MANUAL, wait_for_driver, continuous_check);
+
+    TEST_ASSERT_EQUAL_MESSAGE(DRIVER_RC_OK, rc, "Init should complete if all parameters are passed and current state is a valid one");
+}
+
+void test_driver_api_init_on_idle_state(void) {
+    // a valid state is idle to allow module initialization
+    current_state = STATE_IDLE;
+
+    enum DriverReturnCode rc = driver_api_init(DRIVER_TYPE_MANUAL, wait_for_driver, continuous_check);
+
+    TEST_ASSERT_EQUAL_MESSAGE(DRIVER_RC_OK, rc, "Init should complete if all parameters are passed and current state is a valid one");
+}
+/*! \} */
+
+/*!
+ * \defgroup driver_api_is_driver_ready Tests for driver_api_is_driver_ready function
+ * \{
+ */
+
+void test_driver_api_is_driver_ready_driver_not_ready(void) {
+    // Simply verify that if the driver readiness check fails,
+    // the function should also fail.
+    enum DriverReturnCode expected_rc = DRIVER_RC_ERROR;
+    wait_for_driver_fake.return_val = expected_rc;
+
+    enum DriverReturnCode rc = driver_api_is_driver_ready();
+
+    TEST_ASSERT_EQUAL_MESSAGE(expected_rc, rc, "If the driver readiness check fails, the API should also fail");
+}
+
+void test_driver_api_is_driver_ready_driver_ready(void) {
+    // Simply verify that if the driver readiness check completes,
+    // the function should also complete.
+    enum DriverReturnCode expected_rc = DRIVER_RC_OK;
+    wait_for_driver_fake.return_val = expected_rc;
+
+    enum DriverReturnCode rc = driver_api_is_driver_ready();
+
+    TEST_ASSERT_EQUAL_MESSAGE(expected_rc, rc, "If the driver readiness check is successful, the API should also be successful");
+}
+/*! \} */
+
+/*!
+ * \defgroup driver_api_continuous_check Tests for driver_api_continuous_check function
+ * \{
+ */
+
+void test_driver_api_continuous_check_fails(void) {
+    // Simply verify that if the continuous check fails,
+    // the function should also fail.
+    enum DriverReturnCode expected_rc = DRIVER_RC_ERROR;
+    continuous_check_fake.return_val = expected_rc;
+
+    enum DriverReturnCode rc = driver_api_continuous_check();
+
+    TEST_ASSERT_EQUAL_MESSAGE(expected_rc, rc, "If the continuous check fails, the API should also fail");
+}
+
+void test_driver_api_continuous_check_completes(void) {
+    // Simply verify that if the continuous check fails,
+    // the function should also fail.
+    enum DriverReturnCode expected_rc = DRIVER_RC_OK;
+    continuous_check_fake.return_val = expected_rc;
+
+    enum DriverReturnCode rc = driver_api_continuous_check();
+
+    TEST_ASSERT_EQUAL_MESSAGE(expected_rc, rc, "If the continuous check is successful, the API should also be successful");
+}
+/*! \} */
+
 int main(void) {
     UNITY_BEGIN();
+
+    /*!
+     * \addtogroup driver_api_init
+     * \{
+     */
+    RUN_TEST(test_driver_api_init_invalid_driver_type);
+    RUN_TEST(test_driver_api_init_null_wait_for_driver_callback);
+    RUN_TEST(test_driver_api_init_null_continuous_check_callback);
+    RUN_TEST(test_driver_api_init_not_in_init_and_idle);
+    RUN_TEST(test_driver_api_init_on_init_state);
+    RUN_TEST(test_driver_api_init_on_idle_state);
+    /*! \} */
+
+    /*!
+     * \addtogroup driver_api_is_driver_ready
+     * \{
+     */
+    RUN_TEST(test_driver_api_is_driver_ready_driver_not_ready);
+    RUN_TEST(test_driver_api_is_driver_ready_driver_ready);
+    /*! \} */
+
+    /*!
+     * \addtogroup driver_api_continuous_check
+     * \{
+     */
+    RUN_TEST(test_driver_api_continuous_check_fails);
+    RUN_TEST(test_driver_api_continuous_check_completes);
+    /*! \} */
 
     return UNITY_END();
 }

--- a/Core/Test/test_driver/test_driver.c
+++ b/Core/Test/test_driver/test_driver.c
@@ -1,0 +1,48 @@
+/*!
+ * \file test_driver.c
+ * \author Dorijan Di Zepp
+ * \date 2026-05-13
+ * \brief Unit tests using FFF for testing the driver module.
+ */
+
+#include <unity.h>
+#include "ecu_fsm.h"
+#include "driver-api.h"
+#include "fff.h"
+#include "eagletrt-api.h"
+
+extern struct DriverHandler driver_handler;
+
+/*!
+ * \note The \c current_state variable is defined in \ref support_external.c.
+ * We use \c extern here to access that global definition during tests.
+ */
+extern state_t current_state;
+
+DEFINE_FFF_GLOBALS;
+
+// mock for driver module
+FAKE_VALUE_FUNC(enum DriverReturnCode, wait_for_driver);
+FAKE_VALUE_FUNC(enum DriverReturnCode, continuous_check);
+
+void setUp(void) {
+    // Reset the global state before each test
+    current_state = STATE_INIT;
+
+    // Initialize driver module
+    driver_api_init(DRIVER_TYPE_MANUAL, wait_for_driver, continuous_check);
+
+    // Reset mock state
+    RESET_FAKE(wait_for_driver);
+    RESET_FAKE(continuous_check);
+
+    FFF_RESET_HISTORY();
+}
+
+/* --- Test Cases --- */
+
+int main(void) {
+    UNITY_BEGIN();
+
+    return UNITY_END();
+}

--- a/Core/Test/test_driver/test_driver.c
+++ b/Core/Test/test_driver/test_driver.c
@@ -91,6 +91,24 @@ void test_driver_api_init_on_idle_state(void) {
 
     TEST_ASSERT_EQUAL_MESSAGE(DRIVER_RC_OK, rc, "Init should complete if all parameters are passed and current state is a valid one");
 }
+
+void test_driver_api_init_unchanged_previous_configuration(void) {
+    // Allow explicitly the possibility to reinitialize the module
+    current_state = STATE_INIT;
+
+    // Zero out memory to be sure no garbage value is present
+    struct DriverHandler expected_driver;
+    memset(&expected_driver, 0, sizeof(struct DriverHandler));
+    expected_driver.driver_type = DRIVER_TYPE_MANUAL;
+    expected_driver.wait_for_driver = wait_for_driver;
+    expected_driver.continuous_check = continuous_check;
+
+    // If the call fails, the previous configuration should be left unchanged
+    // to avoid erasing of information
+    driver_api_init(DRIVER_TYPE_AS, wait_for_driver, NULL);
+
+    TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&expected_driver, &driver_handler, sizeof(struct DriverHandler), "The driver handler configuration should be left unchanged in case of a failed initialization");
+}
 /*! \} */
 
 /*!
@@ -162,6 +180,7 @@ int main(void) {
     RUN_TEST(test_driver_api_init_not_in_init_and_idle);
     RUN_TEST(test_driver_api_init_on_init_state);
     RUN_TEST(test_driver_api_init_on_idle_state);
+    RUN_TEST(test_driver_api_init_unchanged_previous_configuration);
     /*! \} */
 
     /*!

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ build_flags =
     -ICore/Inc/ecu/pedals
     -ICore/Inc/ecu/tractive-system
     -ICore/Inc/ecu/raspberry
+    -ICore/Inc/ecu/driver
     -IDrivers/STM32F7xx_HAL_Driver/Inc
     -IDrivers/STM32F7xx_HAL_Driver/Inc/Legacy
     -IDrivers/CMSIS/Device/ST/STM32F7xx/Include
@@ -67,6 +68,7 @@ build_flags =
     -ICore/Inc/ecu/pedals
     -ICore/Inc/ecu/tractive-system
     -ICore/Inc/ecu/raspberry
+    -ICore/Inc/ecu/driver
     -ICore/Test/include
 
 build_src_filter =
@@ -75,5 +77,7 @@ build_src_filter =
     +<Core/Src/ecu/pedals/>
     +<Core/Src/ecu/tractive-system/>
     +<Core/Src/ecu/raspberry/>
+    +<Core/Src/ecu/driver/>
+    +<Core/Test/support/> ;file containing the definition of external variables
 
 lib_deps = https://github.com/eagletrt/libeagletrt-sw.git#v0.1.0


### PR DESCRIPTION
# Purpose
This pull request introduces the driver module. The primary goal is to provide a structured way to select the current vehicle driver (Manual or AS) and expose an interface to:

- Indicate the active driver type across the system.

- Verify driver readiness (essential for the transition to the Ready-to-Drive state).

- Execute continuous safety checks to ensure operational parameters are maintained during driving.

# Overview
- Module implementation: Built a driver-agnostic handler that uses callbacks to execute specific logic.

- FSM state dependency: The API includes safety logic that restricts driver initialization or switching to the INIT and IDLE states of the FSM.

- Unit testing: Integrated a test suite using Unity and FFF to validate state guards and callback execution.

- Linker support: Introduced `support_external.c` helper file. This was required to provide a physical definition for the extern `current_state` variable, which is normally located in `main.c` but is inaccessible during native unit testing.

# Guidance
Nothing in particular. The code is quite simple to follow and review.
