### PR TITLE
Logger module

### DIFF
--- a/Core/Inc/ecu/logger/logger-api.h
+++ b/Core/Inc/ecu/logger/logger-api.h
@@ -1,7 +1,7 @@
 /*!
  * \file logger-api.h
  * \author Dorijan Di Zepp
- * \date 2026-06-12
+ * \date 2026-06-14
  * \brief API interface for initializing and writing to the system logger.
  */
 
@@ -12,28 +12,25 @@
 
 /*!
  * \brief Initializes the logger storage and binds it to an active PAL context instance.
- * \note The struct PalHandler passed to this module should be dedicated solely to 
+ * \note The struct \ref PalHandler passed to this module should be dedicated solely to 
  * the physical interface used for logging (e.g. UART). 
  * If your system interfaces with separate physical protocols (such as a CAN bus), 
- * a distinct, separate `PalHandler` instance must be initialized for that peripheral 
- * to prevent transmission queue collisions and driver conflicts.
- * \warning If the \ref LoggerState passed is invalid, by default the logger will be disabled.
+ * a distinct, separate \ref PalHandler instance must be initialized for that peripheral 
+ * to prevent transmission queue collisions and conflicts.
  * \param[in] pal_h Pointer to the initialized PAL configuration tracking block.
- * \param[in] state Indicate whether the logger should log any string passed or not after initialization.
+ * \param[in] logger_state Runtime flag: true to enable log output immediately, false to initialize muted.
  * \retval LOGGER_RC_OK if setup succeeds.
- * \retval LOGGER_RC_ERROR if the input pointer is \c NULL.
+ * \retval LOGGER_RC_NULL_POINTER if the input pointer \p pal_h is \c NULL.
  */
-enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h, enum LoggerState state);
+enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h, bool logger_state);
 
 /*!
  * \brief Modifies the runtime state of the logger dynamically.
  * \details Can be used to change printing behavior at runtime, such as enabling 
  * full logging during testing or limiting it during production loops.
- * \param[in] state Target state to enable or disable logging.
- * \retval LOGGER_RC_OK if the state has been successfully updated or matches the current configuration.
- * \retval LOGGER_RC_ERROR if the state couldn't be updated (e.g bad state input).
+ * \param[in] logger_state Target state to enable (true) or disable (false) logging.
  */
-enum LoggerReturnCode logger_api_set_state(enum LoggerState state);
+void logger_api_set_state(bool logger_state);
 
 /*!
  * \brief Dispatches a formatted log message over the registered PAL UART interface.
@@ -41,7 +38,7 @@ enum LoggerReturnCode logger_api_set_state(enum LoggerState state);
  * \param[in] level Severity level of the outgoing record.
  * \param[in] format Standard printf-style format configuration string.
  * \param[in] ... Variable argument listing.
- * \retval LOGGER_RC_OK Operation completed successfully and data was processed by the PAL or the logger is disabled.
+ * \retval LOGGER_RC_OK Operation completed successfully and data was processed by the PAL, or the logger is disabled.
  * \retval LOGGER_RC_NULL_POINTER An invalid NULL pointer was passed for the format string or the internal module handler is uninitialized.
  * \retval LOGGER_RC_TRANSMISSION_ERROR String generation failed or the downstream PAL physical hardware transmission encountered a failure.
  * \retval LOGGER_RC_BUFFER_FULL The underlying PAL transmission queue or logging buffer has become saturated and cannot accept new records.

--- a/Core/Inc/ecu/logger/logger-api.h
+++ b/Core/Inc/ecu/logger/logger-api.h
@@ -1,7 +1,7 @@
 /*!
  * \file logger-api.h
  * \author Dorijan Di Zepp
- * \date 2026-06-01
+ * \date 2026-06-12
  * \brief API interface for initializing and writing to the system logger.
  */
 
@@ -17,11 +17,23 @@
  * If your system interfaces with separate physical protocols (such as a CAN bus), 
  * a distinct, separate `PalHandler` instance must be initialized for that peripheral 
  * to prevent transmission queue collisions and driver conflicts.
+ * \warning If the \ref LoggerState passed is invalid, by default the logger will be disabled.
  * \param[in] pal_h Pointer to the initialized PAL configuration tracking block.
+ * \param[in] state Indicate whether the logger should log any string passed or not after initialization.
  * \retval LOGGER_RC_OK if setup succeeds.
- * \retval LOGGER_RC_ERROR if the input pointer is NULL.
+ * \retval LOGGER_RC_ERROR if the input pointer is \c NULL.
  */
-enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h);
+enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h, enum LoggerState state);
+
+/*!
+ * \brief Modifies the runtime state of the logger dynamically.
+ * \details Can be used to change printing behavior at runtime, such as enabling 
+ * full logging during testing or limiting it during production loops.
+ * \param[in] state Target state to enable or disable logging.
+ * \retval LOGGER_RC_OK if the state has been successfully updated or matches the current configuration.
+ * \retval LOGGER_RC_ERROR if the state couldn't be updated (e.g bad state input).
+ */
+enum LoggerReturnCode logger_api_set_state(enum LoggerState state);
 
 /*!
  * \brief Dispatches a formatted log message over the registered PAL UART interface.
@@ -29,9 +41,9 @@ enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h);
  * \param[in] level Severity level of the outgoing record.
  * \param[in] format Standard printf-style format configuration string.
  * \param[in] ... Variable argument listing.
- * \retval LOGGER_RC_OK Operation completed successfully and data was processed by the PAL.
+ * \retval LOGGER_RC_OK Operation completed successfully and data was processed by the PAL or the logger is disabled.
  * \retval LOGGER_RC_NULL_POINTER An invalid NULL pointer was passed for the format string or the internal module handler is uninitialized.
- * \retval LOGGER_RC_TRANSMISSION_ERROR String generation failed, or the downstream PAL physical hardware transmission encountered a failure.
+ * \retval LOGGER_RC_TRANSMISSION_ERROR String generation failed or the downstream PAL physical hardware transmission encountered a failure.
  * \retval LOGGER_RC_BUFFER_FULL The underlying PAL transmission queue or logging buffer has become saturated and cannot accept new records.
  */
 enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format, ...);

--- a/Core/Inc/ecu/logger/logger-api.h
+++ b/Core/Inc/ecu/logger/logger-api.h
@@ -24,13 +24,15 @@
 enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h);
 
 /*!
- * \brief Formally dispatches a formatted log message over the registered PAL UART interface.
+ * \brief Dispatches a formatted log message over the registered PAL UART interface.
  * \details Leverages C variable arguments to provide printf-style formatting.
  * \param[in] level Severity level of the outgoing record.
  * \param[in] format Standard printf-style format configuration string.
  * \param[in] ... Variable argument listing.
- * \retval LOGGER_RC_OK if the message was successfully queued and processed by PAL.
- * \retval LOGGER_RC_ERROR if formatting failed, or PAL encountered an IO/size constraint.
+ * \retval LOGGER_RC_OK Operation completed successfully and data was processed by the PAL.
+ * \retval LOGGER_RC_NULL_POINTER An invalid NULL pointer was passed for the format string or the internal module handler is uninitialized.
+ * \retval LOGGER_RC_TRANSMISSION_ERROR String generation failed, or the downstream PAL physical hardware transmission encountered a failure.
+ * \retval LOGGER_RC_BUFFER_FULL The underlying PAL transmission queue or logging buffer has become saturated and cannot accept new records.
  */
 enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format, ...);
 

--- a/Core/Inc/ecu/logger/logger-api.h
+++ b/Core/Inc/ecu/logger/logger-api.h
@@ -1,0 +1,37 @@
+/*!
+ * \file logger-api.h
+ * \author Dorijan Di Zepp
+ * \date 2026-06-01
+ * \brief API interface for initializing and writing to the system logger.
+ */
+
+#ifndef LOGGER_API_H
+#define LOGGER_API_H
+
+#include "logger.h"
+
+/*!
+ * \brief Initializes the logger storage and binds it to an active PAL context instance.
+ * \note The struct PalHandler passed to this module should be dedicated solely to 
+ * the physical interface used for logging (e.g. UART). 
+ * If your system interfaces with separate physical protocols (such as a CAN bus), 
+ * a distinct, separate `PalHandler` instance must be initialized for that peripheral 
+ * to prevent transmission queue collisions and driver conflicts.
+ * \param[in] pal_h Pointer to the initialized PAL configuration tracking block.
+ * \retval LOGGER_RC_OK if setup succeeds.
+ * \retval LOGGER_RC_ERROR if the input pointer is NULL.
+ */
+enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h);
+
+/*!
+ * \brief Formally dispatches a formatted log message over the registered PAL UART interface.
+ * \details Leverages C variable arguments to provide printf-style formatting.
+ * \param[in] level Severity level of the outgoing record.
+ * \param[in] format Standard printf-style format configuration string.
+ * \param[in] ... Variable argument listing.
+ * \retval LOGGER_RC_OK if the message was successfully queued and processed by PAL.
+ * \retval LOGGER_RC_ERROR if formatting failed, or PAL encountered an IO/size constraint.
+ */
+enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format, ...);
+
+#endif

--- a/Core/Inc/ecu/logger/logger.h
+++ b/Core/Inc/ecu/logger/logger.h
@@ -11,12 +11,20 @@
 #include <stdint.h>
 #include "pal-api.h"
 
-/*!
+/**
  * \brief System logger return/status codes.
  */
 enum LoggerReturnCode {
-    LOGGER_RC_OK = 0,
-    LOGGER_RC_ERROR = 1
+    LOGGER_RC_OK,                   /*!< Operation completed successfully. */
+    LOGGER_RC_NULL_POINTER,         /*!< An invalid NULL pointer was passed directly to the logger. */
+    LOGGER_RC_NOT_INITIALIZED,      /*!< Logging was attempted before initializing the module. */
+    LOGGER_RC_FORMAT_ERROR,         /*!< String parsing or vsnprintf formatting failed. */
+    LOGGER_RC_PAL_INVALID_ARGUMENT, /*!< PAL rejected parameter data provided by the logger. */
+    LOGGER_RC_PAL_NULL_POINTER,     /*!< Downstream PAL encountered an unexpected NULL pointer. */
+    LOGGER_RC_PAL_IO_ERROR,         /*!< Downstream PAL physical hardware transmission failed. */
+    LOGGER_RC_PAL_QUEUE_FULL,       /*!< The PAL transmission queue is completely full. */
+    LOGGER_RC_PAL_MESSAGE_TOO_BIG,  /*!< Formatted string exceeded internal PAL message limits. */
+    LOGGER_RC_PAL_GENERIC_ERROR     /*!< Fallback for unhandled or unexpected PAL return codes. */
 };
 
 /*!

--- a/Core/Inc/ecu/logger/logger.h
+++ b/Core/Inc/ecu/logger/logger.h
@@ -1,7 +1,7 @@
 /*!
  * \file logger.h
  * \author Dorijan Di Zepp
- * \date 2026-06-01
+ * \date 2026-06-12
  * \brief Data types, enums and structures for the system logger module.
  */
 
@@ -16,9 +16,19 @@
  */
 enum LoggerReturnCode {
     LOGGER_RC_OK,                 /*!< Operation completed successfully. */
+    LOGGER_RC_ERROR,              /*!< Operation not completed due to an internal error. */
     LOGGER_RC_NULL_POINTER,       /*!< An invalid NULL pointer was passed directly to the logger. */
     LOGGER_RC_TRANSMISSION_ERROR, /*!< Downstream PAL physical hardware transmission failed or generic error occurred. */
     LOGGER_RC_BUFFER_FULL         /*!< The logging medium or underlying PAL transmission queue is completely full. */
+};
+
+/*!
+ * \brief Operational states for the logger.
+ */
+enum LoggerState {
+    LOGGER_STATE_DISABLED, /*!< The logger will ignore any logging request. */
+    LOGGER_STATE_ENABLED,  /*!< The logger will try to log any information passed. */
+    LOGGER_STATE_COUNT,    /*!< Sentinel value used exclusively to verify enum parameter validity. */
 };
 
 /*!
@@ -38,6 +48,7 @@ enum LoggerLevel {
  */
 struct LoggerHandler {
     struct PalHandler *pal_handler; /*!< Referenced PAL tracking instance for UART routing. */
+    enum LoggerState state;         /*!< Current runtime filtering state of the logger. */
 };
 
 #endif

--- a/Core/Inc/ecu/logger/logger.h
+++ b/Core/Inc/ecu/logger/logger.h
@@ -1,0 +1,41 @@
+/*!
+ * \file logger.h
+ * \author Dorijan Di Zepp
+ * \date 2026-06-01
+ * \brief Data types, enums and structures for the system logger module.
+ */
+
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <stdint.h>
+#include "pal-api.h"
+
+/*!
+ * \brief System logger return/status codes.
+ */
+enum LoggerReturnCode {
+    LOGGER_RC_OK = 0,
+    LOGGER_RC_ERROR = 1
+};
+
+/*!
+ * \brief Severity level for logging records.
+ */
+enum LoggerLevel {
+    LOGGER_LEVEL_DEBUG = 0, /*!< Verbose diagnostics for developer use. */
+    LOGGER_LEVEL_INFO = 1,  /*!< Routine operational updates. */
+    LOGGER_LEVEL_WARN = 2,  /*!< Non-fatal anomalies or timing retries. */
+    LOGGER_LEVEL_ERROR = 3  /*!< Fatal system faults. */
+};
+
+/*!
+ * \brief Internal context state handler container.
+ * \note The \ref pal_handler member points to a unique PAL interface dedicated 
+ * to logging/console output (typically mapped to a specific UART channel).
+ */
+struct LoggerHandler {
+    struct PalHandler *pal_handler; /*!< Referenced PAL tracking instance for UART routing. */
+};
+
+#endif

--- a/Core/Inc/ecu/logger/logger.h
+++ b/Core/Inc/ecu/logger/logger.h
@@ -1,14 +1,15 @@
 /*!
  * \file logger.h
  * \author Dorijan Di Zepp
- * \date 2026-06-12
- * \brief Data types, enums and structures for the system logger module.
+ * \date 2026-06-14
+ * \brief Data types and structures for the system logger module.
  */
 
 #ifndef LOGGER_H
 #define LOGGER_H
 
 #include <stdint.h>
+#include <stdbool.h>
 #include "pal-api.h"
 
 /*!
@@ -23,22 +24,14 @@ enum LoggerReturnCode {
 };
 
 /*!
- * \brief Operational states for the logger.
- */
-enum LoggerState {
-    LOGGER_STATE_DISABLED, /*!< The logger will ignore any logging request. */
-    LOGGER_STATE_ENABLED,  /*!< The logger will try to log any information passed. */
-    LOGGER_STATE_COUNT,    /*!< Sentinel value used exclusively to verify enum parameter validity. */
-};
-
-/*!
  * \brief Severity level for logging records.
  */
 enum LoggerLevel {
     LOGGER_LEVEL_DEBUG, /*!< Verbose diagnostics for developer use. */
     LOGGER_LEVEL_INFO,  /*!< Routine operational updates. */
     LOGGER_LEVEL_WARN,  /*!< Non-fatal anomalies or timing retries. */
-    LOGGER_LEVEL_ERROR  /*!< Fatal system faults. */
+    LOGGER_LEVEL_ERROR, /*!< Fatal system faults. */
+    LOGGER_LEVEL_COUNT  /*!< Sentinel value to validate the logger level. */
 };
 
 /*!
@@ -48,7 +41,7 @@ enum LoggerLevel {
  */
 struct LoggerHandler {
     struct PalHandler *pal_handler; /*!< Referenced PAL tracking instance for UART routing. */
-    enum LoggerState state;         /*!< Current runtime filtering state of the logger. */
+    bool logger_state;              /*!< Active execution flag: true to process logs, false to mute logging output. */
 };
 
 #endif

--- a/Core/Inc/ecu/logger/logger.h
+++ b/Core/Inc/ecu/logger/logger.h
@@ -11,30 +11,24 @@
 #include <stdint.h>
 #include "pal-api.h"
 
-/**
+/*!
  * \brief System logger return/status codes.
  */
 enum LoggerReturnCode {
-    LOGGER_RC_OK,                   /*!< Operation completed successfully. */
-    LOGGER_RC_NULL_POINTER,         /*!< An invalid NULL pointer was passed directly to the logger. */
-    LOGGER_RC_NOT_INITIALIZED,      /*!< Logging was attempted before initializing the module. */
-    LOGGER_RC_FORMAT_ERROR,         /*!< String parsing or vsnprintf formatting failed. */
-    LOGGER_RC_PAL_INVALID_ARGUMENT, /*!< PAL rejected parameter data provided by the logger. */
-    LOGGER_RC_PAL_NULL_POINTER,     /*!< Downstream PAL encountered an unexpected NULL pointer. */
-    LOGGER_RC_PAL_IO_ERROR,         /*!< Downstream PAL physical hardware transmission failed. */
-    LOGGER_RC_PAL_QUEUE_FULL,       /*!< The PAL transmission queue is completely full. */
-    LOGGER_RC_PAL_MESSAGE_TOO_BIG,  /*!< Formatted string exceeded internal PAL message limits. */
-    LOGGER_RC_PAL_GENERIC_ERROR     /*!< Fallback for unhandled or unexpected PAL return codes. */
+    LOGGER_RC_OK,                 /*!< Operation completed successfully. */
+    LOGGER_RC_NULL_POINTER,       /*!< An invalid NULL pointer was passed directly to the logger. */
+    LOGGER_RC_TRANSMISSION_ERROR, /*!< Downstream PAL physical hardware transmission failed or generic error occurred. */
+    LOGGER_RC_BUFFER_FULL         /*!< The logging medium or underlying PAL transmission queue is completely full. */
 };
 
 /*!
  * \brief Severity level for logging records.
  */
 enum LoggerLevel {
-    LOGGER_LEVEL_DEBUG = 0, /*!< Verbose diagnostics for developer use. */
-    LOGGER_LEVEL_INFO = 1,  /*!< Routine operational updates. */
-    LOGGER_LEVEL_WARN = 2,  /*!< Non-fatal anomalies or timing retries. */
-    LOGGER_LEVEL_ERROR = 3  /*!< Fatal system faults. */
+    LOGGER_LEVEL_DEBUG, /*!< Verbose diagnostics for developer use. */
+    LOGGER_LEVEL_INFO,  /*!< Routine operational updates. */
+    LOGGER_LEVEL_WARN,  /*!< Non-fatal anomalies or timing retries. */
+    LOGGER_LEVEL_ERROR  /*!< Fatal system faults. */
 };
 
 /*!

--- a/Core/Src/ecu/logger/logger-api.c
+++ b/Core/Src/ecu/logger/logger-api.c
@@ -1,7 +1,7 @@
 /*!
  * \file logger-api.c
  * \author Dorijan Di Zepp
- * \date 2026-06-01
+ * \date 2026-06-12
  * \brief API execution handling for logging records.
  */
 
@@ -19,18 +19,35 @@
  */
 EAGLETRT_STATIC struct LoggerHandler logger_handler;
 
-enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h) {
+enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h, enum LoggerState state) {
     if (pal_h == NULL) {
         return LOGGER_RC_NULL_POINTER;
     }
 
+    // If the state passed is invalid, disable automatically
+    logger_handler.state = (state < LOGGER_STATE_COUNT) ? state : LOGGER_STATE_DISABLED;
     logger_handler.pal_handler = pal_h;
+
+    return LOGGER_RC_OK;
+}
+
+enum LoggerReturnCode logger_api_set_state(enum LoggerState state) {
+    if (state >= LOGGER_STATE_COUNT) {
+        return LOGGER_RC_ERROR;
+    }
+
+    logger_handler.state = state;
     return LOGGER_RC_OK;
 }
 
 enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format, ...) {
     if (logger_handler.pal_handler == NULL || format == NULL) {
         return LOGGER_RC_NULL_POINTER;
+    }
+
+    // Return OK as the behavior is the one expected
+    if (logger_handler.state == LOGGER_STATE_DISABLED) {
+        return LOGGER_RC_OK;
     }
 
     char final_buffer[LOGGER_MAX_LINE_SIZE];
@@ -70,10 +87,11 @@ enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format,
         return LOGGER_RC_TRANSMISSION_ERROR; // Format parsing exception
     }
 
-    int total_len = offset + body_len;
+    // Measure the actual string safely populated inside the buffer boundary
+    size_t actual_len = strlen(final_buffer);
 
     // Determine transmission size including the string null terminator to match PAL style
-    uint32_t tx_bytes = (total_len >= (int)LOGGER_MAX_LINE_SIZE) ? (uint32_t)LOGGER_MAX_LINE_SIZE : (uint32_t)(total_len + 1);
+    uint32_t tx_bytes = (uint32_t)(actual_len + 1U);
 
     // Queue the formatted record into PAL and collapse lower-level parameters into abstract behaviors
     enum PalReturnCode pal_rc = pal_api_add_to_tx_queue(logger_handler.pal_handler, final_buffer, tx_bytes);

--- a/Core/Src/ecu/logger/logger-api.c
+++ b/Core/Src/ecu/logger/logger-api.c
@@ -1,0 +1,89 @@
+/*!
+ * \file logger-api.c
+ * \author Dorijan Di Zepp
+ * \date 2026-06-01
+ * \brief API execution handling for logging records.
+ */
+
+#include "logger-api.h"
+#include "eagletrt-api.h"
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+
+#define LOGGER_MAX_LINE_SIZE (64U)
+
+/*!
+ * \brief Internal module handler.
+ * \details Hidden from external linkage to enforce API-only access.
+ */
+EAGLETRT_STATIC struct LoggerHandler logger_handler;
+
+enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h) {
+    if (pal_h == NULL) {
+        return LOGGER_RC_ERROR;
+    }
+
+    logger_handler.pal_handler = pal_h;
+    return LOGGER_RC_OK;
+}
+
+enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format, ...) {
+    if (logger_handler.pal_handler == NULL) {
+        return LOGGER_RC_ERROR;
+    }
+
+    char final_buffer[LOGGER_MAX_LINE_SIZE];
+    int offset = 0;
+
+    // Prepend metadata severity tags
+    switch (level) {
+        case LOGGER_LEVEL_DEBUG:
+            offset = snprintf(final_buffer, sizeof(final_buffer), "[DEBUG] ");
+            break;
+        case LOGGER_LEVEL_INFO:
+            offset = snprintf(final_buffer, sizeof(final_buffer), "[INFO]  ");
+            break;
+        case LOGGER_LEVEL_WARN:
+            offset = snprintf(final_buffer, sizeof(final_buffer), "[WARN]  ");
+            break;
+        case LOGGER_LEVEL_ERROR:
+            offset = snprintf(final_buffer, sizeof(final_buffer), "[ERROR] ");
+            break;
+        default:
+            offset = snprintf(final_buffer, sizeof(final_buffer), "[LOG]   ");
+            break;
+    }
+
+    // Verify no anomalies or truncations occurred during tag placement
+    if (offset < 0 || offset >= (int)sizeof(final_buffer)) {
+        return LOGGER_RC_ERROR;
+    }
+
+    // Process variable args into the remaining space of the local buffer
+    va_list args;
+    va_start(args, format);
+    int body_len = vsnprintf(final_buffer + offset, sizeof(final_buffer) - (size_t)offset, format, args);
+    va_end(args);
+
+    if (body_len < 0) {
+        return LOGGER_RC_ERROR; // Format parsing exception
+    }
+
+    int total_len = offset + body_len;
+
+    // Determine transmission size including the string null terminator to match PAL style
+    uint32_t tx_bytes = (total_len >= (int)LOGGER_MAX_LINE_SIZE) ? (uint32_t)LOGGER_MAX_LINE_SIZE : (uint32_t)(total_len + 1);
+
+    // Queue the formatted record into PAL
+    if (pal_api_add_to_tx_queue(logger_handler.pal_handler, final_buffer, tx_bytes) != PAL_RC_OK) {
+        return LOGGER_RC_ERROR;
+    }
+
+    // Process/Flush the queue immediately so diagnostics output synchronously
+    if (pal_api_process_tx(logger_handler.pal_handler) != PAL_RC_OK) {
+        return LOGGER_RC_ERROR;
+    }
+
+    return LOGGER_RC_OK;
+}

--- a/Core/Src/ecu/logger/logger-api.c
+++ b/Core/Src/ecu/logger/logger-api.c
@@ -19,9 +19,36 @@
  */
 EAGLETRT_STATIC struct LoggerHandler logger_handler;
 
+/*!
+ * \brief Translates native PAL return codes into explicit logger sub-errors.
+ */
+EAGLETRT_STATIC enum LoggerReturnCode prv_logger_map_pal_return_code(enum PalReturnCode pal_rc) {
+    switch (pal_rc) {
+        case PAL_RC_OK:
+            return LOGGER_RC_OK;
+        case PAL_RC_INVALID_ARGUMENT:
+            return LOGGER_RC_PAL_INVALID_ARGUMENT;
+        case PAL_RC_NULL_POINTER:
+            return LOGGER_RC_PAL_NULL_POINTER;
+        case PAL_RC_IO_ERROR:
+            return LOGGER_RC_PAL_IO_ERROR;
+        case PAL_RC_QUEUE_FULL:
+            return LOGGER_RC_PAL_QUEUE_FULL;
+        case PAL_RC_MESSAGE_TOO_BIG:
+            return LOGGER_RC_PAL_MESSAGE_TOO_BIG;
+
+        // Fallbacks for codes that shouldn't typically happen during a TX log string push
+        case PAL_RC_QUEUE_EMPTY:
+        case PAL_RC_DESERIALIZATION_ERROR:
+        case PAL_RC_SERIALIZATION_ERROR:
+        default:
+            return LOGGER_RC_PAL_GENERIC_ERROR;
+    }
+}
+
 enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h) {
     if (pal_h == NULL) {
-        return LOGGER_RC_ERROR;
+        return LOGGER_RC_NULL_POINTER;
     }
 
     logger_handler.pal_handler = pal_h;
@@ -30,7 +57,7 @@ enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h) {
 
 enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format, ...) {
     if (logger_handler.pal_handler == NULL) {
-        return LOGGER_RC_ERROR;
+        return LOGGER_RC_NOT_INITIALIZED;
     }
 
     char final_buffer[LOGGER_MAX_LINE_SIZE];
@@ -57,7 +84,7 @@ enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format,
 
     // Verify no anomalies or truncations occurred during tag placement
     if (offset < 0 || offset >= (int)sizeof(final_buffer)) {
-        return LOGGER_RC_ERROR;
+        return LOGGER_RC_FORMAT_ERROR;
     }
 
     // Process variable args into the remaining space of the local buffer
@@ -67,7 +94,7 @@ enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format,
     va_end(args);
 
     if (body_len < 0) {
-        return LOGGER_RC_ERROR; // Format parsing exception
+        return LOGGER_RC_FORMAT_ERROR; // Format parsing exception
     }
 
     int total_len = offset + body_len;
@@ -75,14 +102,16 @@ enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format,
     // Determine transmission size including the string null terminator to match PAL style
     uint32_t tx_bytes = (total_len >= (int)LOGGER_MAX_LINE_SIZE) ? (uint32_t)LOGGER_MAX_LINE_SIZE : (uint32_t)(total_len + 1);
 
-    // Queue the formatted record into PAL
-    if (pal_api_add_to_tx_queue(logger_handler.pal_handler, final_buffer, tx_bytes) != PAL_RC_OK) {
-        return LOGGER_RC_ERROR;
+    // Queue the formatted record into PAL and map explicit failure states
+    enum PalReturnCode pal_rc = pal_api_add_to_tx_queue(logger_handler.pal_handler, final_buffer, tx_bytes);
+    if (pal_rc != PAL_RC_OK) {
+        return prv_logger_map_pal_return_code(pal_rc);
     }
 
     // Process/Flush the queue immediately so diagnostics output synchronously
-    if (pal_api_process_tx(logger_handler.pal_handler) != PAL_RC_OK) {
-        return LOGGER_RC_ERROR;
+    pal_rc = pal_api_process_tx(logger_handler.pal_handler);
+    if (pal_rc != PAL_RC_OK) {
+        return prv_logger_map_pal_return_code(pal_rc);
     }
 
     return LOGGER_RC_OK;

--- a/Core/Src/ecu/logger/logger-api.c
+++ b/Core/Src/ecu/logger/logger-api.c
@@ -19,33 +19,6 @@
  */
 EAGLETRT_STATIC struct LoggerHandler logger_handler;
 
-/*!
- * \brief Translates native PAL return codes into explicit logger sub-errors.
- */
-EAGLETRT_STATIC enum LoggerReturnCode prv_logger_map_pal_return_code(enum PalReturnCode pal_rc) {
-    switch (pal_rc) {
-        case PAL_RC_OK:
-            return LOGGER_RC_OK;
-        case PAL_RC_INVALID_ARGUMENT:
-            return LOGGER_RC_PAL_INVALID_ARGUMENT;
-        case PAL_RC_NULL_POINTER:
-            return LOGGER_RC_PAL_NULL_POINTER;
-        case PAL_RC_IO_ERROR:
-            return LOGGER_RC_PAL_IO_ERROR;
-        case PAL_RC_QUEUE_FULL:
-            return LOGGER_RC_PAL_QUEUE_FULL;
-        case PAL_RC_MESSAGE_TOO_BIG:
-            return LOGGER_RC_PAL_MESSAGE_TOO_BIG;
-
-        // Fallbacks for codes that shouldn't typically happen during a TX log string push
-        case PAL_RC_QUEUE_EMPTY:
-        case PAL_RC_DESERIALIZATION_ERROR:
-        case PAL_RC_SERIALIZATION_ERROR:
-        default:
-            return LOGGER_RC_PAL_GENERIC_ERROR;
-    }
-}
-
 enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h) {
     if (pal_h == NULL) {
         return LOGGER_RC_NULL_POINTER;
@@ -56,8 +29,8 @@ enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h) {
 }
 
 enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format, ...) {
-    if (logger_handler.pal_handler == NULL) {
-        return LOGGER_RC_NOT_INITIALIZED;
+    if (logger_handler.pal_handler == NULL || format == NULL) {
+        return LOGGER_RC_NULL_POINTER;
     }
 
     char final_buffer[LOGGER_MAX_LINE_SIZE];
@@ -69,22 +42,22 @@ enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format,
             offset = snprintf(final_buffer, sizeof(final_buffer), "[DEBUG] ");
             break;
         case LOGGER_LEVEL_INFO:
-            offset = snprintf(final_buffer, sizeof(final_buffer), "[INFO]  ");
+            offset = snprintf(final_buffer, sizeof(final_buffer), "[INFO] ");
             break;
         case LOGGER_LEVEL_WARN:
-            offset = snprintf(final_buffer, sizeof(final_buffer), "[WARN]  ");
+            offset = snprintf(final_buffer, sizeof(final_buffer), "[WARN] ");
             break;
         case LOGGER_LEVEL_ERROR:
             offset = snprintf(final_buffer, sizeof(final_buffer), "[ERROR] ");
             break;
         default:
-            offset = snprintf(final_buffer, sizeof(final_buffer), "[LOG]   ");
+            offset = snprintf(final_buffer, sizeof(final_buffer), "[LOG] ");
             break;
     }
 
     // Verify no anomalies or truncations occurred during tag placement
     if (offset < 0 || offset >= (int)sizeof(final_buffer)) {
-        return LOGGER_RC_FORMAT_ERROR;
+        return LOGGER_RC_TRANSMISSION_ERROR;
     }
 
     // Process variable args into the remaining space of the local buffer
@@ -94,7 +67,7 @@ enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format,
     va_end(args);
 
     if (body_len < 0) {
-        return LOGGER_RC_FORMAT_ERROR; // Format parsing exception
+        return LOGGER_RC_TRANSMISSION_ERROR; // Format parsing exception
     }
 
     int total_len = offset + body_len;
@@ -102,16 +75,22 @@ enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format,
     // Determine transmission size including the string null terminator to match PAL style
     uint32_t tx_bytes = (total_len >= (int)LOGGER_MAX_LINE_SIZE) ? (uint32_t)LOGGER_MAX_LINE_SIZE : (uint32_t)(total_len + 1);
 
-    // Queue the formatted record into PAL and map explicit failure states
+    // Queue the formatted record into PAL and collapse lower-level parameters into abstract behaviors
     enum PalReturnCode pal_rc = pal_api_add_to_tx_queue(logger_handler.pal_handler, final_buffer, tx_bytes);
     if (pal_rc != PAL_RC_OK) {
-        return prv_logger_map_pal_return_code(pal_rc);
+        if (pal_rc == PAL_RC_QUEUE_FULL) {
+            return LOGGER_RC_BUFFER_FULL;
+        }
+        return LOGGER_RC_TRANSMISSION_ERROR;
     }
 
     // Process/Flush the queue immediately so diagnostics output synchronously
     pal_rc = pal_api_process_tx(logger_handler.pal_handler);
     if (pal_rc != PAL_RC_OK) {
-        return prv_logger_map_pal_return_code(pal_rc);
+        if (pal_rc == PAL_RC_QUEUE_FULL) {
+            return LOGGER_RC_BUFFER_FULL;
+        }
+        return LOGGER_RC_TRANSMISSION_ERROR;
     }
 
     return LOGGER_RC_OK;

--- a/Core/Src/ecu/logger/logger-api.c
+++ b/Core/Src/ecu/logger/logger-api.c
@@ -1,7 +1,7 @@
 /*!
  * \file logger-api.c
  * \author Dorijan Di Zepp
- * \date 2026-06-12
+ * \date 2026-06-14
  * \brief API execution handling for logging records.
  */
 
@@ -19,25 +19,19 @@
  */
 EAGLETRT_STATIC struct LoggerHandler logger_handler;
 
-enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h, enum LoggerState state) {
+enum LoggerReturnCode logger_api_init(struct PalHandler *pal_h, bool logger_state) {
     if (pal_h == NULL) {
         return LOGGER_RC_NULL_POINTER;
     }
 
-    // If the state passed is invalid, disable automatically
-    logger_handler.state = (state < LOGGER_STATE_COUNT) ? state : LOGGER_STATE_DISABLED;
+    logger_handler.logger_state = logger_state;
     logger_handler.pal_handler = pal_h;
 
     return LOGGER_RC_OK;
 }
 
-enum LoggerReturnCode logger_api_set_state(enum LoggerState state) {
-    if (state >= LOGGER_STATE_COUNT) {
-        return LOGGER_RC_ERROR;
-    }
-
-    logger_handler.state = state;
-    return LOGGER_RC_OK;
+void logger_api_set_state(bool logger_state) {
+    logger_handler.logger_state = logger_state;
 }
 
 enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format, ...) {
@@ -45,32 +39,26 @@ enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format,
         return LOGGER_RC_NULL_POINTER;
     }
 
-    // Return OK as the behavior is the one expected
-    if (logger_handler.state == LOGGER_STATE_DISABLED) {
+    // Return OK immediately if the logger is currently muted/disabled
+    if (!logger_handler.logger_state) {
         return LOGGER_RC_OK;
     }
 
     char final_buffer[LOGGER_MAX_LINE_SIZE];
-    int offset = 0;
 
-    // Prepend metadata severity tags
-    switch (level) {
-        case LOGGER_LEVEL_DEBUG:
-            offset = snprintf(final_buffer, sizeof(final_buffer), "[DEBUG] ");
-            break;
-        case LOGGER_LEVEL_INFO:
-            offset = snprintf(final_buffer, sizeof(final_buffer), "[INFO] ");
-            break;
-        case LOGGER_LEVEL_WARN:
-            offset = snprintf(final_buffer, sizeof(final_buffer), "[WARN] ");
-            break;
-        case LOGGER_LEVEL_ERROR:
-            offset = snprintf(final_buffer, sizeof(final_buffer), "[ERROR] ");
-            break;
-        default:
-            offset = snprintf(final_buffer, sizeof(final_buffer), "[LOG] ");
-            break;
-    }
+    // Lookup table replacing the switch-case matrix
+    char *const log_headers[] = {
+        [LOGGER_LEVEL_DEBUG] = "[DEBUG]",
+        [LOGGER_LEVEL_INFO] = "[INFO]",
+        [LOGGER_LEVEL_WARN] = "[WARN]",
+        [LOGGER_LEVEL_ERROR] = "[ERROR]"
+    };
+
+    // Safely check bounds using LOGGER_LEVEL_COUNT before accessing memory
+    // For default [LOG] will be left in case the logger level specified is not valid
+    const char *header = (level < LOGGER_LEVEL_COUNT) ? log_headers[level] : "[LOG]";
+
+    int offset = snprintf(final_buffer, sizeof(final_buffer), "%s ", header);
 
     // Verify no anomalies or truncations occurred during tag placement
     if (offset < 0 || offset >= (int)sizeof(final_buffer)) {
@@ -90,10 +78,10 @@ enum LoggerReturnCode logger_api_log(enum LoggerLevel level, const char *format,
     // Measure the actual string safely populated inside the buffer boundary
     size_t actual_len = strlen(final_buffer);
 
-    // Determine transmission size including the string null terminator to match PAL style
+    // Determine transmission size including the string null terminator
     uint32_t tx_bytes = (uint32_t)(actual_len + 1U);
 
-    // Queue the formatted record into PAL and collapse lower-level parameters into abstract behaviors
+    // Queue the formatted record into PAL
     enum PalReturnCode pal_rc = pal_api_add_to_tx_queue(logger_handler.pal_handler, final_buffer, tx_bytes);
     if (pal_rc != PAL_RC_OK) {
         if (pal_rc == PAL_RC_QUEUE_FULL) {

--- a/Core/Test/test_logger/test_logger.c
+++ b/Core/Test/test_logger/test_logger.c
@@ -1,7 +1,7 @@
 /*!
  * \file test_logger.c
  * \author Dorijan Di Zepp
- * \date 2026-06-12
+ * \date 2026-06-14
  * \brief Unit tests using FFF for testing the logger module.
  */
 
@@ -15,7 +15,7 @@
 
 extern struct LoggerHandler logger_handler;
 
-// Global variables to manage a PAL usage
+// Global variables to manage PAL usage
 EAGLETRT_STATIC struct PalHandler pal_handler;
 EAGLETRT_STATIC struct ArenaAllocatorHandler arena_allocator_handler;
 
@@ -26,11 +26,11 @@ EAGLETRT_STATIC struct ArenaAllocatorHandler arena_allocator_handler;
 
 DEFINE_FFF_GLOBALS;
 
-// mocks for logger
+// Mocks for logger
 FAKE_VALUE_FUNC(enum PalReturnCode, mock_uart_hardware_transmit, const struct PalMessage *);
 
 void setUp(void) {
-    // initialize the arena allocator to allocate pal
+    // Initialize the arena allocator to allocate pal
     arena_allocator_api_init(&arena_allocator_handler);
 
     pal_api_init(&pal_handler,
@@ -43,10 +43,10 @@ void setUp(void) {
                  NULL,
                  &arena_allocator_handler);
 
-    // initialize the logger with default enabled state
-    logger_api_init(&pal_handler, LOGGER_STATE_ENABLED);
+    // Initialize the logger default enabled state
+    logger_api_init(&pal_handler, true);
 
-    // reset mock state
+    // Reset mock state
     RESET_FAKE(mock_uart_hardware_transmit);
 
     FFF_RESET_HISTORY();
@@ -62,7 +62,7 @@ void setUp(void) {
 void test_logger_api_init_should_fail_on_null_pointer(void) {
     logger_handler.pal_handler = NULL;
 
-    enum LoggerReturnCode rc = logger_api_init(NULL, LOGGER_STATE_ENABLED);
+    enum LoggerReturnCode rc = logger_api_init(NULL, true);
 
     TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_NULL_POINTER, rc, "Initialization loop failed to return NULL_POINTER when passed a null hardware binding");
     TEST_ASSERT_NULL_MESSAGE(logger_handler.pal_handler,
@@ -72,11 +72,11 @@ void test_logger_api_init_should_fail_on_null_pointer(void) {
 void test_logger_api_init_should_succeed_with_correct_pal_handler(void) {
     logger_handler.pal_handler = NULL;
 
-    enum LoggerReturnCode rc = logger_api_init(&pal_handler, LOGGER_STATE_ENABLED);
+    enum LoggerReturnCode rc = logger_api_init(&pal_handler, true);
 
     TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_OK, rc, "Initialization loop failed to return OK when passed valid peripheral dependencies");
     TEST_ASSERT_EQUAL_PTR_MESSAGE(&pal_handler, logger_handler.pal_handler, "Internal module hardware interface address binding mismatch");
-    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_STATE_ENABLED, logger_handler.state, "Initial startup tracking state configuration mismatch");
+    TEST_ASSERT_TRUE_MESSAGE(logger_handler.logger_state, "Initial startup tracking state configuration mismatch");
 }
 /*! \} */
 
@@ -86,30 +86,21 @@ void test_logger_api_init_should_succeed_with_correct_pal_handler(void) {
  */
 
 void test_logger_api_set_state_should_successfully_change_to_disabled(void) {
-    logger_api_init(&pal_handler, LOGGER_STATE_ENABLED);
+    logger_api_init(&pal_handler, true);
 
-    enum LoggerReturnCode rc = logger_api_set_state(LOGGER_STATE_DISABLED);
+    // logger_api_set_state now returns void
+    logger_api_set_state(false);
 
-    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_OK, rc, "Setter failed to return OK when transitioning layout to DISABLED");
-    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_STATE_DISABLED, logger_handler.state, "Logger tracking state attribute was not updated to DISABLED");
+    TEST_ASSERT_FALSE_MESSAGE(logger_handler.logger_state, "Logger tracking state attribute was not updated to false (DISABLED)");
 }
 
 void test_logger_api_set_state_should_successfully_change_to_enabled(void) {
-    logger_api_init(&pal_handler, LOGGER_STATE_DISABLED);
+    logger_api_init(&pal_handler, false);
 
-    enum LoggerReturnCode rc = logger_api_set_state(LOGGER_STATE_ENABLED);
+    // logger_api_set_state now returns void
+    logger_api_set_state(true);
 
-    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_OK, rc, "Setter failed to return OK when transitioning layout to ENABLED");
-    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_STATE_ENABLED, logger_handler.state, "Logger tracking state attribute was not updated to ENABLED");
-}
-
-void test_logger_api_set_state_should_fail_on_out_of_bounds_sentinel(void) {
-    logger_api_init(&pal_handler, LOGGER_STATE_ENABLED);
-
-    enum LoggerReturnCode rc = logger_api_set_state(LOGGER_STATE_COUNT);
-
-    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_ERROR, rc, "Setter failed to reject out-of-bounds sentinel parameters with an ERROR return value");
-    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_STATE_ENABLED, logger_handler.state, "Logger tracking state was corrupted or overwritten by an invalid enum boundary entry");
+    TEST_ASSERT_TRUE_MESSAGE(logger_handler.logger_state, "Logger tracking state attribute was not updated to true (ENABLED)");
 }
 /*! \} */
 
@@ -128,7 +119,7 @@ void test_logger_api_log_should_fail_if_module_not_initialized(void) {
 }
 
 void test_logger_api_log_should_silently_bypass_and_return_ok_when_disabled(void) {
-    logger_api_init(&pal_handler, LOGGER_STATE_DISABLED);
+    logger_api_init(&pal_handler, false);
 
     enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_ERROR, "Critical SDC Exception Code %d", 500);
 
@@ -199,7 +190,6 @@ int main(void) {
      */
     RUN_TEST(test_logger_api_set_state_should_successfully_change_to_disabled);
     RUN_TEST(test_logger_api_set_state_should_successfully_change_to_enabled);
-    RUN_TEST(test_logger_api_set_state_should_fail_on_out_of_bounds_sentinel);
     /*! \} */
 
     /*!

--- a/Core/Test/test_logger/test_logger.c
+++ b/Core/Test/test_logger/test_logger.c
@@ -3,6 +3,12 @@
  * \author Dorijan Di Zepp
  * \date 2026-06-01
  * \brief Unit tests using FFF for testing the logger module.
+ * \note When validating the return codes in unit tests, it is sufficient to 
+ * explicitly verify a representative subset of PAL-mapped failures 
+ * (such as `LOGGER_RC_PAL_IO_ERROR` and `LOGGER_RC_PAL_QUEUE_FULL`). 
+ * Testing every individual error permutation is not required, as the underlying 
+ * mapping infrastructure is proven via these representative paths, and unhandled 
+ * or impossible transmission states safely fallback to `LOGGER_RC_PAL_GENERIC_ERROR`.
  */
 
 #include "unity.h"
@@ -60,9 +66,21 @@ void setUp(void) {
  */
 
 void test_logger_api_init_should_fail_on_null_pointer(void) {
+    logger_handler.pal_handler = NULL;
+
     enum LoggerReturnCode rc = logger_api_init(NULL);
 
-    TEST_ASSERT_EQUAL_INT(LOGGER_RC_ERROR, rc);
+    TEST_ASSERT_EQUAL_INT(LOGGER_RC_NULL_POINTER, rc);
+    TEST_ASSERT_NULL(logger_handler.pal_handler);
+}
+
+void test_logger_api_init_should_succeed_with_correct_pal_handler(void) {
+    logger_handler.pal_handler = NULL;
+
+    enum LoggerReturnCode rc = logger_api_init(&pal_handler);
+
+    TEST_ASSERT_EQUAL_INT(LOGGER_RC_OK, rc);
+    TEST_ASSERT_EQUAL_PTR(&pal_handler, logger_handler.pal_handler);
 }
 /*! \} */
 
@@ -77,7 +95,7 @@ void test_logger_api_log_should_fail_if_module_not_initialized(void) {
 
     enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_INFO, "Test");
 
-    TEST_ASSERT_EQUAL_INT(LOGGER_RC_ERROR, rc);
+    TEST_ASSERT_EQUAL_INT(LOGGER_RC_NOT_INITIALIZED, rc);
     // verify that the callback is not called
     TEST_ASSERT_EQUAL_INT(0, mock_uart_hardware_transmit_fake.call_count);
 }
@@ -101,7 +119,16 @@ void test_logger_api_log_should_bubble_error_if_hardware_fails(void) {
 
     enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_ERROR, "SDC Trip");
 
-    TEST_ASSERT_EQUAL_INT(LOGGER_RC_ERROR, rc);
+    TEST_ASSERT_EQUAL_INT(LOGGER_RC_PAL_IO_ERROR, rc);
+    TEST_ASSERT_EQUAL_INT(1, mock_uart_hardware_transmit_fake.call_count);
+}
+
+void test_logger_api_log_should_bubble_error_if_queue_overflows(void) {
+    mock_uart_hardware_transmit_fake.return_val = PAL_RC_QUEUE_FULL;
+
+    enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_WARN, "Queue Maxed");
+
+    TEST_ASSERT_EQUAL_INT(LOGGER_RC_PAL_QUEUE_FULL, rc);
     TEST_ASSERT_EQUAL_INT(1, mock_uart_hardware_transmit_fake.call_count);
 }
 
@@ -129,6 +156,7 @@ int main(void) {
      * \{
      */
     RUN_TEST(test_logger_api_init_should_fail_on_null_pointer);
+    RUN_TEST(test_logger_api_init_should_succeed_with_correct_pal_handler);
     /*! \} */
 
     /*!
@@ -138,6 +166,7 @@ int main(void) {
     RUN_TEST(test_logger_api_log_should_fail_if_module_not_initialized);
     RUN_TEST(test_logger_api_log_should_format_and_pass_successfully_to_hardware);
     RUN_TEST(test_logger_api_log_should_bubble_error_if_hardware_fails);
+    RUN_TEST(test_logger_api_log_should_bubble_error_if_queue_overflows);
     RUN_TEST(test_logger_api_log_should_clamp_oversized_strings_at_max_msg_size);
     /*! \} */
 

--- a/Core/Test/test_logger/test_logger.c
+++ b/Core/Test/test_logger/test_logger.c
@@ -3,12 +3,6 @@
  * \author Dorijan Di Zepp
  * \date 2026-06-01
  * \brief Unit tests using FFF for testing the logger module.
- * \note When validating the return codes in unit tests, it is sufficient to 
- * explicitly verify a representative subset of PAL-mapped failures 
- * (such as `LOGGER_RC_PAL_IO_ERROR` and `LOGGER_RC_PAL_QUEUE_FULL`). 
- * Testing every individual error permutation is not required, as the underlying 
- * mapping infrastructure is proven via these representative paths, and unhandled 
- * or impossible transmission states safely fallback to `LOGGER_RC_PAL_GENERIC_ERROR`.
  */
 
 #include "unity.h"
@@ -95,7 +89,7 @@ void test_logger_api_log_should_fail_if_module_not_initialized(void) {
 
     enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_INFO, "Test");
 
-    TEST_ASSERT_EQUAL_INT(LOGGER_RC_NOT_INITIALIZED, rc);
+    TEST_ASSERT_EQUAL_INT(LOGGER_RC_NULL_POINTER, rc);
     // verify that the callback is not called
     TEST_ASSERT_EQUAL_INT(0, mock_uart_hardware_transmit_fake.call_count);
 }
@@ -111,7 +105,7 @@ void test_logger_api_log_should_format_and_pass_successfully_to_hardware(void) {
     // verify the message passed to the callback is the expected one
     const struct PalMessage *sent_msg = mock_uart_hardware_transmit_fake.arg0_val;
     TEST_ASSERT_NOT_NULL(sent_msg);
-    TEST_ASSERT_EQUAL_STRING("[INFO]  Volt: 12", (const char *)sent_msg->payload);
+    TEST_ASSERT_EQUAL_STRING("[INFO] Volt: 12", (const char *)sent_msg->payload);
 }
 
 void test_logger_api_log_should_bubble_error_if_hardware_fails(void) {
@@ -119,7 +113,7 @@ void test_logger_api_log_should_bubble_error_if_hardware_fails(void) {
 
     enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_ERROR, "SDC Trip");
 
-    TEST_ASSERT_EQUAL_INT(LOGGER_RC_PAL_IO_ERROR, rc);
+    TEST_ASSERT_EQUAL_INT(LOGGER_RC_TRANSMISSION_ERROR, rc);
     TEST_ASSERT_EQUAL_INT(1, mock_uart_hardware_transmit_fake.call_count);
 }
 
@@ -128,7 +122,7 @@ void test_logger_api_log_should_bubble_error_if_queue_overflows(void) {
 
     enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_WARN, "Queue Maxed");
 
-    TEST_ASSERT_EQUAL_INT(LOGGER_RC_PAL_QUEUE_FULL, rc);
+    TEST_ASSERT_EQUAL_INT(LOGGER_RC_BUFFER_FULL, rc);
     TEST_ASSERT_EQUAL_INT(1, mock_uart_hardware_transmit_fake.call_count);
 }
 

--- a/Core/Test/test_logger/test_logger.c
+++ b/Core/Test/test_logger/test_logger.c
@@ -1,0 +1,145 @@
+/*!
+ * \file test_logger.c
+ * \author Dorijan Di Zepp
+ * \date 2026-06-01
+ * \brief Unit tests using FFF for testing the logger module.
+ */
+
+#include "unity.h"
+#include "fff.h"
+#include "logger-api.h"
+#include "eagletrt-api.h"
+#include "pal-api.h"
+#include "arena-allocator-api.h"
+#include <string.h>
+
+extern struct LoggerHandler logger_handler;
+
+// Global variables to manage a PAL usage
+EAGLETRT_STATIC struct PalHandler pal_handler;
+EAGLETRT_STATIC struct ArenaAllocatorHandler arena_allocator_handler;
+
+// Configurations for PAL
+#define TEST_UART_MAX_MSG_SIZE (64U)
+#define TEST_RX_CAPACITY (10U)
+#define TEST_TX_CAPACITY (10U)
+
+DEFINE_FFF_GLOBALS;
+
+// mocks for logger
+FAKE_VALUE_FUNC(enum PalReturnCode, mock_uart_hardware_transmit, const struct PalMessage *);
+
+void setUp(void) {
+    // initialize the arena allocator to allocate pal
+    arena_allocator_api_init(&arena_allocator_handler);
+
+    pal_api_init(&pal_handler,
+                 TEST_RX_CAPACITY,
+                 TEST_TX_CAPACITY,
+                 TEST_UART_MAX_MSG_SIZE,
+                 NULL,
+                 mock_uart_hardware_transmit,
+                 NULL,
+                 NULL,
+                 &arena_allocator_handler);
+
+    // initialize the logger
+    logger_api_init(&pal_handler);
+
+    // reset mock state
+    RESET_FAKE(mock_uart_hardware_transmit);
+
+    FFF_RESET_HISTORY();
+}
+
+/* --- Test Cases --- */
+
+/*!
+ * \defgroup logger_api_init Tests for logger_api_init function
+ * \{
+ */
+
+void test_logger_api_init_should_fail_on_null_pointer(void) {
+    enum LoggerReturnCode rc = logger_api_init(NULL);
+
+    TEST_ASSERT_EQUAL_INT(LOGGER_RC_ERROR, rc);
+}
+/*! \} */
+
+/*!
+ * \defgroup logger_api_log Tests for logger_api_log function
+ * \{
+ */
+
+void test_logger_api_log_should_fail_if_module_not_initialized(void) {
+    // Force the global module handler into an uninitialized state by injecting NULL
+    logger_handler.pal_handler = NULL;
+
+    enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_INFO, "Test");
+
+    TEST_ASSERT_EQUAL_INT(LOGGER_RC_ERROR, rc);
+    // verify that the callback is not called
+    TEST_ASSERT_EQUAL_INT(0, mock_uart_hardware_transmit_fake.call_count);
+}
+
+void test_logger_api_log_should_format_and_pass_successfully_to_hardware(void) {
+    mock_uart_hardware_transmit_fake.return_val = PAL_RC_OK;
+
+    enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_INFO, "Volt: %d", 12);
+
+    TEST_ASSERT_EQUAL_INT(LOGGER_RC_OK, rc);
+    TEST_ASSERT_EQUAL_INT(1, mock_uart_hardware_transmit_fake.call_count);
+
+    // verify the message passed to the callback is the expected one
+    const struct PalMessage *sent_msg = mock_uart_hardware_transmit_fake.arg0_val;
+    TEST_ASSERT_NOT_NULL(sent_msg);
+    TEST_ASSERT_EQUAL_STRING("[INFO]  Volt: 12", (const char *)sent_msg->payload);
+}
+
+void test_logger_api_log_should_bubble_error_if_hardware_fails(void) {
+    mock_uart_hardware_transmit_fake.return_val = PAL_RC_IO_ERROR;
+
+    enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_ERROR, "SDC Trip");
+
+    TEST_ASSERT_EQUAL_INT(LOGGER_RC_ERROR, rc);
+    TEST_ASSERT_EQUAL_INT(1, mock_uart_hardware_transmit_fake.call_count);
+}
+
+void test_logger_api_log_should_clamp_oversized_strings_at_max_msg_size(void) {
+    mock_uart_hardware_transmit_fake.return_val = PAL_RC_OK;
+    const char *long_msg = "This is a very long log trace that will definitely exceed sixty four bytes";
+
+    enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_DEBUG, "%s", long_msg);
+
+    TEST_ASSERT_EQUAL_INT(LOGGER_RC_OK, rc);
+    TEST_ASSERT_EQUAL_INT(1, mock_uart_hardware_transmit_fake.call_count);
+
+    // verify the callback received a message long exactly the maximum possible
+    const struct PalMessage *sent_msg = mock_uart_hardware_transmit_fake.arg0_val;
+    TEST_ASSERT_NOT_NULL(sent_msg);
+    TEST_ASSERT_EQUAL_UINT32(TEST_UART_MAX_MSG_SIZE, sent_msg->size);
+}
+/*! \} */
+
+int main(void) {
+    UNITY_BEGIN();
+
+    /*!
+     * \addtogroup logger_api_init
+     * \{
+     */
+    RUN_TEST(test_logger_api_init_should_fail_on_null_pointer);
+    /*! \} */
+
+    /*!
+     * \addtogroup logger_api_log
+     * \{
+     */
+    RUN_TEST(test_logger_api_log_should_fail_if_module_not_initialized);
+    RUN_TEST(test_logger_api_log_should_format_and_pass_successfully_to_hardware);
+    RUN_TEST(test_logger_api_log_should_bubble_error_if_hardware_fails);
+    RUN_TEST(test_logger_api_log_should_clamp_oversized_strings_at_max_msg_size);
+    /*! \} */
+
+    return UNITY_END();
+}

--- a/Core/Test/test_logger/test_logger.c
+++ b/Core/Test/test_logger/test_logger.c
@@ -1,7 +1,7 @@
 /*!
  * \file test_logger.c
  * \author Dorijan Di Zepp
- * \date 2026-06-01
+ * \date 2026-06-12
  * \brief Unit tests using FFF for testing the logger module.
  */
 
@@ -43,8 +43,8 @@ void setUp(void) {
                  NULL,
                  &arena_allocator_handler);
 
-    // initialize the logger
-    logger_api_init(&pal_handler);
+    // initialize the logger with default enabled state
+    logger_api_init(&pal_handler, LOGGER_STATE_ENABLED);
 
     // reset mock state
     RESET_FAKE(mock_uart_hardware_transmit);
@@ -62,19 +62,54 @@ void setUp(void) {
 void test_logger_api_init_should_fail_on_null_pointer(void) {
     logger_handler.pal_handler = NULL;
 
-    enum LoggerReturnCode rc = logger_api_init(NULL);
+    enum LoggerReturnCode rc = logger_api_init(NULL, LOGGER_STATE_ENABLED);
 
-    TEST_ASSERT_EQUAL_INT(LOGGER_RC_NULL_POINTER, rc);
-    TEST_ASSERT_NULL(logger_handler.pal_handler);
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_NULL_POINTER, rc, "Initialization loop failed to return NULL_POINTER when passed a null hardware binding");
+    TEST_ASSERT_NULL_MESSAGE(logger_handler.pal_handler,
+                             "Internal context handle pointer was corruptly initialized when passed a null value");
 }
 
 void test_logger_api_init_should_succeed_with_correct_pal_handler(void) {
     logger_handler.pal_handler = NULL;
 
-    enum LoggerReturnCode rc = logger_api_init(&pal_handler);
+    enum LoggerReturnCode rc = logger_api_init(&pal_handler, LOGGER_STATE_ENABLED);
 
-    TEST_ASSERT_EQUAL_INT(LOGGER_RC_OK, rc);
-    TEST_ASSERT_EQUAL_PTR(&pal_handler, logger_handler.pal_handler);
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_OK, rc, "Initialization loop failed to return OK when passed valid peripheral dependencies");
+    TEST_ASSERT_EQUAL_PTR_MESSAGE(&pal_handler, logger_handler.pal_handler, "Internal module hardware interface address binding mismatch");
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_STATE_ENABLED, logger_handler.state, "Initial startup tracking state configuration mismatch");
+}
+/*! \} */
+
+/*!
+ * \defgroup logger_api_set_state Tests for logger_api_set_state function
+ * \{
+ */
+
+void test_logger_api_set_state_should_successfully_change_to_disabled(void) {
+    logger_api_init(&pal_handler, LOGGER_STATE_ENABLED);
+
+    enum LoggerReturnCode rc = logger_api_set_state(LOGGER_STATE_DISABLED);
+
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_OK, rc, "Setter failed to return OK when transitioning layout to DISABLED");
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_STATE_DISABLED, logger_handler.state, "Logger tracking state attribute was not updated to DISABLED");
+}
+
+void test_logger_api_set_state_should_successfully_change_to_enabled(void) {
+    logger_api_init(&pal_handler, LOGGER_STATE_DISABLED);
+
+    enum LoggerReturnCode rc = logger_api_set_state(LOGGER_STATE_ENABLED);
+
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_OK, rc, "Setter failed to return OK when transitioning layout to ENABLED");
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_STATE_ENABLED, logger_handler.state, "Logger tracking state attribute was not updated to ENABLED");
+}
+
+void test_logger_api_set_state_should_fail_on_out_of_bounds_sentinel(void) {
+    logger_api_init(&pal_handler, LOGGER_STATE_ENABLED);
+
+    enum LoggerReturnCode rc = logger_api_set_state(LOGGER_STATE_COUNT);
+
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_ERROR, rc, "Setter failed to reject out-of-bounds sentinel parameters with an ERROR return value");
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_STATE_ENABLED, logger_handler.state, "Logger tracking state was corrupted or overwritten by an invalid enum boundary entry");
 }
 /*! \} */
 
@@ -84,14 +119,21 @@ void test_logger_api_init_should_succeed_with_correct_pal_handler(void) {
  */
 
 void test_logger_api_log_should_fail_if_module_not_initialized(void) {
-    // Force the global module handler into an uninitialized state by injecting NULL
     logger_handler.pal_handler = NULL;
 
-    enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_INFO, "Test");
+    enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_INFO, "Test Execution");
 
-    TEST_ASSERT_EQUAL_INT(LOGGER_RC_NULL_POINTER, rc);
-    // verify that the callback is not called
-    TEST_ASSERT_EQUAL_INT(0, mock_uart_hardware_transmit_fake.call_count);
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_NULL_POINTER, rc, "Logger did not crash cleanly or return NULL_POINTER when uninitialized downstream hooks were targeted");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, mock_uart_hardware_transmit_fake.call_count, "Hardware transmission loop triggered on a dangling uninitialized context structure");
+}
+
+void test_logger_api_log_should_silently_bypass_and_return_ok_when_disabled(void) {
+    logger_api_init(&pal_handler, LOGGER_STATE_DISABLED);
+
+    enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_ERROR, "Critical SDC Exception Code %d", 500);
+
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_OK, rc, "Logger failed to return standard validation OK when processing log loops while explicitly disabled");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, mock_uart_hardware_transmit_fake.call_count, "Downstream physical transmission layer was targeted while logging execution was turned off");
 }
 
 void test_logger_api_log_should_format_and_pass_successfully_to_hardware(void) {
@@ -99,31 +141,30 @@ void test_logger_api_log_should_format_and_pass_successfully_to_hardware(void) {
 
     enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_INFO, "Volt: %d", 12);
 
-    TEST_ASSERT_EQUAL_INT(LOGGER_RC_OK, rc);
-    TEST_ASSERT_EQUAL_INT(1, mock_uart_hardware_transmit_fake.call_count);
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_OK, rc, "Logger failed to successfully process a standard, correctly bounded string configuration");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, mock_uart_hardware_transmit_fake.call_count, "Logger failed to trigger downstream physical hardware abstraction transmission");
 
-    // verify the message passed to the callback is the expected one
     const struct PalMessage *sent_msg = mock_uart_hardware_transmit_fake.arg0_val;
-    TEST_ASSERT_NOT_NULL(sent_msg);
-    TEST_ASSERT_EQUAL_STRING("[INFO] Volt: 12", (const char *)sent_msg->payload);
+    TEST_ASSERT_NOT_NULL_MESSAGE(sent_msg, "Passed physical hardware message structure pointer evaluates to NULL");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("[INFO] Volt: 12", (const char *)sent_msg->payload, "Formatted metadata tag generation or payload sequence mismatch");
 }
 
 void test_logger_api_log_should_bubble_error_if_hardware_fails(void) {
     mock_uart_hardware_transmit_fake.return_val = PAL_RC_IO_ERROR;
 
-    enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_ERROR, "SDC Trip");
+    enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_ERROR, "SDC Trip Frame Detected");
 
-    TEST_ASSERT_EQUAL_INT(LOGGER_RC_TRANSMISSION_ERROR, rc);
-    TEST_ASSERT_EQUAL_INT(1, mock_uart_hardware_transmit_fake.call_count);
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_TRANSMISSION_ERROR, rc, "Logger failed to encapsulate downstream low-level hardware IO errors into generic transmission status codes");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, mock_uart_hardware_transmit_fake.call_count, "Downstream abstraction transmission handler was bypassed entirely when tracking fault parameters");
 }
 
 void test_logger_api_log_should_bubble_error_if_queue_overflows(void) {
     mock_uart_hardware_transmit_fake.return_val = PAL_RC_QUEUE_FULL;
 
-    enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_WARN, "Queue Maxed");
+    enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_WARN, "Queue Buffer Capacity Saturation Warning");
 
-    TEST_ASSERT_EQUAL_INT(LOGGER_RC_BUFFER_FULL, rc);
-    TEST_ASSERT_EQUAL_INT(1, mock_uart_hardware_transmit_fake.call_count);
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_BUFFER_FULL, rc, "Logger module failed to trap down-stream interface queue saturation limits cleanly");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, mock_uart_hardware_transmit_fake.call_count, "Downstream physical loop abstraction wasn't evaluated on buffer overflow triggers");
 }
 
 void test_logger_api_log_should_clamp_oversized_strings_at_max_msg_size(void) {
@@ -132,13 +173,12 @@ void test_logger_api_log_should_clamp_oversized_strings_at_max_msg_size(void) {
 
     enum LoggerReturnCode rc = logger_api_log(LOGGER_LEVEL_DEBUG, "%s", long_msg);
 
-    TEST_ASSERT_EQUAL_INT(LOGGER_RC_OK, rc);
-    TEST_ASSERT_EQUAL_INT(1, mock_uart_hardware_transmit_fake.call_count);
+    TEST_ASSERT_EQUAL_MESSAGE(LOGGER_RC_OK, rc, "Logger component layout failed to return OK on runtime boundary truncation tasks");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, mock_uart_hardware_transmit_fake.call_count, "Downstream abstraction transmission handler bypassed when testing clamped buffer arrays");
 
-    // verify the callback received a message long exactly the maximum possible
     const struct PalMessage *sent_msg = mock_uart_hardware_transmit_fake.arg0_val;
-    TEST_ASSERT_NOT_NULL(sent_msg);
-    TEST_ASSERT_EQUAL_UINT32(TEST_UART_MAX_MSG_SIZE, sent_msg->size);
+    TEST_ASSERT_NOT_NULL_MESSAGE(sent_msg, "Targeted transmission pointer payload evaluates to NULL on truncation checks");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(TEST_UART_MAX_MSG_SIZE, sent_msg->size, "Logger processing execution did not match the physical tracking limits of the system array size definition");
 }
 /*! \} */
 
@@ -154,10 +194,20 @@ int main(void) {
     /*! \} */
 
     /*!
+     * \addtogroup logger_api_set_state
+     * \{
+     */
+    RUN_TEST(test_logger_api_set_state_should_successfully_change_to_disabled);
+    RUN_TEST(test_logger_api_set_state_should_successfully_change_to_enabled);
+    RUN_TEST(test_logger_api_set_state_should_fail_on_out_of_bounds_sentinel);
+    /*! \} */
+
+    /*!
      * \addtogroup logger_api_log
      * \{
      */
     RUN_TEST(test_logger_api_log_should_fail_if_module_not_initialized);
+    RUN_TEST(test_logger_api_log_should_silently_bypass_and_return_ok_when_disabled);
     RUN_TEST(test_logger_api_log_should_format_and_pass_successfully_to_hardware);
     RUN_TEST(test_logger_api_log_should_bubble_error_if_hardware_fails);
     RUN_TEST(test_logger_api_log_should_bubble_error_if_queue_overflows);

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,6 +27,7 @@ build_flags =
     -ICore/Inc/ecu/tractive-system
     -ICore/Inc/ecu/raspberry
     -ICore/Inc/ecu/inverters
+    -ICore/Inc/ecu/logger
     -IDrivers/STM32F7xx_HAL_Driver/Inc
     -IDrivers/STM32F7xx_HAL_Driver/Inc/Legacy
     -IDrivers/CMSIS/Device/ST/STM32F7xx/Include
@@ -38,7 +39,9 @@ build_src_filter =
     +<Drivers/STM32F7xx_HAL_Driver/Src>
     -<Drivers/STM32F7xx_HAL_Driver/Src/*_template.c>
 
-lib_deps = https://github.com/eagletrt/libeagletrt-sw.git#v0.1.0
+lib_deps = 
+    https://github.com/eagletrt/libeagletrt-sw.git#v0.1.0
+    https://github.com/eagletrt/libpal-sw.git#v0.1.0
 
 check_tool = clangtidy
 check_flags =
@@ -71,6 +74,7 @@ build_flags =
     -ICore/Inc/ecu/tractive-system
     -ICore/Inc/ecu/raspberry
     -ICore/Inc/ecu/inverters
+    -ICore/Inc/ecu/logger
     -ICore/Test/include
 
 build_src_filter =
@@ -80,8 +84,11 @@ build_src_filter =
     +<Core/Src/ecu/tractive-system/>
     +<Core/Src/ecu/raspberry/>
     +<Core/Src/ecu/inverters/>
+    +<Core/Src/ecu/logger/>
 
-lib_deps = https://github.com/eagletrt/libeagletrt-sw.git#v0.1.0
+lib_deps = 
+    https://github.com/eagletrt/libeagletrt-sw.git#v0.1.0
+    https://github.com/eagletrt/libpal-sw.git#v0.1.0
 
 [env:bootloader]
 platform = ststm32


### PR DESCRIPTION
# Purpose
This PR introduces a logger module designed for system-wide diagnostic.

The module leverages standard C variable argument lists (<stdarg.h>) to provide standard printf-style string formatting, combined with configurable severity level prefixes (DEBUG, INFO, WARN, ERROR).

By architecture design, this module is completely decoupled from physical hardware peripherals. It interfaces exclusively with the PAL library, meaning logging statements can be dynamically rerouted to alternative channels (such as individual UART ports or CAN networks) seamlessly at the initialization.

# Overview
The PR introduces the new logger module with its unit testing.

# Guidance
Nothing in particular to follow.
